### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-alpine
+
+# A trailing slash after /opt/app will create the directory if doesn't exist
+COPY target/iv-delivery.jar /opt/app/
+
+CMD [ "java", "-jar", "/opt/app/iv-delivery.jar" ]

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 	</dependencies>
 
 	<build>
+		<finalName>${project.artifactId}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## iv-deliver: Adding a Dockerfile to be able to generate an image

## Problem
In order to generate an image, a Dockerfile must be created to provide instructions for Docker.

## Solution

- Updated the pom.xml to include a constant final name for the project artifact.
- Added a Dockerfile to be able to generate a Docker image.

## Results
Below is the output of building the iv-delivery app image with the new Dockerfile.

<img width="697" alt="Screenshot 2024-06-25 at 9 53 31 AM" src="https://github.com/DSACMS/iv-delivery/assets/141157097/0d1bfc40-862a-495a-8b07-28e7143f1b6d">
